### PR TITLE
[#15] Added API message CRUD operations

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -2,9 +2,10 @@
 
 from typing import Any, List
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.orm import Session
 
+from . import schemas as sch
 from .models import Message
 
 
@@ -17,13 +18,8 @@ def count_messages(session: Session) -> int:
     return int(result.scalar_one())
 
 
-def create_test_messages(session: Session) -> None:
-    create_message(session, content="What's on your mind?")
-    create_message(session, content="I'm so scared for tonight")
-
-
-def create_message(session: Session, content: str) -> Message:
-    message = Message(content=content)
+def create_message(session: Session, new_message: sch.CreateMessage) -> Message:
+    message = Message(content=new_message.content)
     session.add(message)
     session.commit()
     session.refresh(message)
@@ -32,4 +28,18 @@ def create_message(session: Session, content: str) -> Message:
 
 def read_messages(session: Session) -> List[Any]:
     result = session.scalars(select(Message)).all()
-    return list(result)  # list() needed for type hinting
+    return list(result)
+
+
+def update_message(session: Session, message: sch.UpdateMessage) -> None:
+    statement = (
+        update(Message).where(Message.id == message.id).values(content=message.content)
+    )
+    session.execute(statement)
+    session.commit()
+
+
+def delete_message(session: Session, message: sch.DeleteItem) -> None:
+    statement = delete(Message).where(Message.id == message.id)
+    session.execute(statement)
+    session.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,13 +5,17 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
+from . import crud, models
+from . import schemas as sch
 from .database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
+# Needed to allow same-origin CORS requests between the web app and API when run locally
+# WARNING: This opens the app up to cross-site scripting attacks
+# TODO: #17 Find a more secure method of allowing same origin requests.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -32,14 +36,36 @@ def get_session() -> Generator[Session, None, None]:
 session_dependency = Depends(get_session)
 
 
+@app.post("/messages/create/", response_model=sch.Message)
+def create_message(
+    message: sch.CreateMessage, session: Session = session_dependency
+) -> models.Message:
+    return crud.create_message(session, message)
+
+
 @app.get("/test/")
 def create_test_messages(session: Session = session_dependency) -> None:
-    crud.create_test_messages(session)
+    create_message(sch.CreateMessage(content="What's on your mind?"), session)
+    create_message(sch.CreateMessage(content="I'm so scared for tonight"), session)
 
 
-@app.get("/messages/", response_model=list[schemas.Message])
+@app.get("/messages/", response_model=list[sch.Message])
 def read_messages(session: Session = session_dependency) -> list[models.Message]:
     return crud.read_messages(session)
+
+
+@app.post("/messages/update/")
+def update_message(
+    message: sch.UpdateMessage, session: Session = session_dependency
+) -> None:
+    crud.update_message(session, message)
+
+
+@app.post("/messages/delete/")
+def delete_message(
+    message: sch.DeleteItem, session: Session = session_dependency
+) -> None:
+    crud.delete_message(session, message)
 
 
 @app.get("/count/", response_model=int)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -3,8 +3,23 @@
 from pydantic import BaseModel, ConfigDict
 
 
-class Message(BaseModel):
+class MessageBase(BaseModel):
+    content: str
+
+
+class Message(MessageBase):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    content: str
+
+
+class CreateMessage(MessageBase):
+    pass
+
+
+class UpdateMessage(MessageBase):
+    id: int
+
+
+class DeleteItem(BaseModel):
+    id: int


### PR DESCRIPTION
## What?
Expanded the API to implement CRUD operations on messages. This resolves #15.

## How?
Similar to previously, operations on the database are implemented in crud.py and then the API is expanded in main.py.

## Where next?
CRUD operations which call the API need to be implemented in the web interface.