### PR TITLE
[#20] Added Codes and CRUD operations to the API

### DIFF
--- a/alembic/versions/91f22d35301a_create_codes_table.py
+++ b/alembic/versions/91f22d35301a_create_codes_table.py
@@ -1,0 +1,30 @@
+"""create codes table
+
+Revision ID: 91f22d35301a
+Revises: 41fb9eb8bce1
+Create Date: 2023-10-12 13:36:41.613095
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "91f22d35301a"
+down_revision: Union[str, None] = "41fb9eb8bce1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "codes",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("code", sa.String, unique=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("codes")

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -6,7 +6,10 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from . import schemas as sch
-from .models import Message
+from .models import Code, Message
+
+# -----------------------------------------------------------------------
+# Messages
 
 
 def count_messages(session: Session) -> int:
@@ -52,7 +55,57 @@ def update_message(session: Session, message: sch.UpdateMessage) -> None:
     session.commit()
 
 
-def delete_message(session: Session, message: sch.DeleteItem) -> None:
+def delete_message(session: Session, message: sch.DeleteMessage) -> None:
     statement = sa.delete(Message).where(Message.id == message.id)
+    session.execute(statement)
+    session.commit()
+
+
+# -----------------------------------------------------------------------
+# Codes
+
+
+def count_codes(session: Session) -> int:
+    result = session.execute(sa.select(sa.func.count(Code.id)))
+    return int(result.scalar_one())
+
+
+def create_code(session: Session, new_code: sch.CreateCode) -> Optional[Code]:
+    parts = new_code.code.split("/")
+    current_code_string = ""
+    current_code = None
+    for part in parts:
+        if not part:
+            continue  # Skip empty string if new_code.code starts with '/'
+        current_code_string += "/" + part
+        check_if_exists = sa.select(Code).where(Code.code == current_code_string)
+        code = session.execute(check_if_exists).scalar_one_or_none()
+        if not code:
+            current_code = Code(code=current_code_string)
+            session.add(current_code)
+    session.commit()
+    session.refresh(current_code)
+    return current_code  # Return only the original
+
+
+def read_codes(session: Session) -> List[Any]:
+    statement = sa.select(Code).order_by(Code.code)
+    result = session.scalars(statement).all()
+    return list(result)
+
+
+def update_code(session: Session, new_code: sch.UpdateCode) -> None:
+    get_old_code = sa.select(Code).where(Code.id == new_code.id)
+    old_code = session.execute(get_old_code).scalar_one()
+    get_subcodes = sa.select(Code).where(Code.code.contains(old_code.code))
+    subcodes = session.execute(get_subcodes).scalars()
+    old_code_length = len(old_code.code)
+    for subcode in subcodes:
+        subcode.code = new_code.code + subcode.code[old_code_length:]  # type: ignore
+    session.commit()
+
+
+def delete_code(session: Session, code: sch.DeleteCode) -> None:
+    statement = sa.delete(Code).where(Code.code.contains(code.code))
     session.execute(statement)
     session.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,12 +37,8 @@ def get_session() -> Generator[Session, None, None]:
 session_dependency = Depends(get_session)
 
 
-@app.post("/messages/create/", response_model=sch.Message)
-def create_message(
-    message: sch.CreateMessage, session: Session = session_dependency
-) -> models.Message:
-    """Create a new message in the database."""
-    return crud.create_message(session, message)
+# -----------------------------------------------------------------------
+# Messages
 
 
 @app.get("/messages/", response_model=list[sch.Message])
@@ -67,6 +63,14 @@ def read_messages(
     )
 
 
+@app.post("/messages/create/", response_model=sch.Message)
+def create_message(
+    message: sch.CreateMessage, session: Session = session_dependency
+) -> models.Message:
+    """Create a new message in the database."""
+    return crud.create_message(session, message)
+
+
 @app.post("/messages/update/")
 def update_message(
     message: sch.UpdateMessage, session: Session = session_dependency
@@ -77,13 +81,51 @@ def update_message(
 
 @app.post("/messages/delete/")
 def delete_message(
-    message: sch.DeleteItem, session: Session = session_dependency
+    message: sch.DeleteMessage, session: Session = session_dependency
 ) -> None:
     """Delete a given message from the database."""
     crud.delete_message(session, message)
 
 
-@app.get("/count/", response_model=int)
-def read_count(session: Session = session_dependency) -> int:
+@app.get("/messages/count/", response_model=int)
+def count_messages(session: Session = session_dependency) -> int:
     """Count the number of messages in the database."""
     return crud.count_messages(session)
+
+
+# -----------------------------------------------------------------------
+# Codes
+
+
+@app.get("/codes/", response_model=list[sch.Code])
+def read_codes(
+    session: Session = session_dependency,
+) -> list[models.Code]:
+    """Read codes from the database."""
+    return crud.read_codes(session=session)
+
+
+@app.post("/codes/create/", response_model=Optional[sch.Code])
+def create_code(
+    code: sch.CreateCode, session: Session = session_dependency
+) -> Optional[models.Code]:
+    """Create a new code in the database if it does not already exist."""
+    return crud.create_code(session, code)
+
+
+@app.post("/codes/update/")
+def update_code(code: sch.UpdateCode, session: Session = session_dependency) -> None:
+    """Update a code in the database."""
+    crud.update_code(session, code)
+
+
+@app.post("/codes/delete/")
+def delete_code(code: sch.DeleteCode, session: Session = session_dependency) -> None:
+    """Delete a given code from the database."""
+    crud.delete_code(session, code)
+
+
+@app.get("/codes/count/", response_model=int)
+def count_codes(session: Session = session_dependency) -> int:
+    """Count the number of codes in the database."""
+    return crud.count_codes(session)

--- a/backend/models.py
+++ b/backend/models.py
@@ -13,3 +13,10 @@ class Message(Base):
 
     id = sa.Column("id", sa.Integer, primary_key=True)
     content = sa.Column("content", sa.String)
+
+
+class Code(Base):
+    __tablename__ = "codes"
+
+    id = sa.Column("id", sa.Integer, primary_key=True)
+    code = sa.Column("code", sa.String, unique=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,7 +1,9 @@
 """Define the Pydantic data schemas."""
-from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
+
+# -----------------------------------------------------------------------
+# Messages
 
 
 class MessageBase(BaseModel):
@@ -14,14 +16,6 @@ class Message(MessageBase):
     id: int
 
 
-class ReadMessages(BaseModel):
-    search: Optional[str]
-    limit: Optional[int]
-    offset: Optional[int]
-    sort_by: Optional[str]
-    sort_asc: Optional[bool]
-
-
 class CreateMessage(MessageBase):
     pass
 
@@ -30,5 +24,31 @@ class UpdateMessage(MessageBase):
     id: int
 
 
-class DeleteItem(BaseModel):
+class DeleteMessage(BaseModel):
     id: int
+
+
+# -----------------------------------------------------------------------
+# Codes
+
+
+class CodeBase(BaseModel):
+    code: str
+
+
+class Code(CodeBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+
+
+class CreateCode(CodeBase):
+    pass
+
+
+class UpdateCode(CodeBase):
+    id: int
+
+
+class DeleteCode(CodeBase):
+    pass


### PR DESCRIPTION
## What
A small PR adding a Codes table to the database and associated CRUD operations to the API.

## Why
The set of codes used to annotate the messages is going to be constantly evolving throughout the project. For this reason, it is important that it is possible to add, remove and update codes.

## How
The codes have a hierarchical structure, thus I have chosen to implement them by enumerating the path for each code in the database. For example, we could have codes: 'emotion', 'emotion/positive', 'emotion/negative', 'emotion/positive/joy'.

To implement the CRUD operations, we have to take special care here:
- Codes, unlike messages, should be unique.
- When creating a code, its parents may also need to be created.
- When updating a code, the update must be applied to all of its subcodes too.
- When deleting a code, all of its subcodes should also be deleted.