### PR TITLE
[#26] Added Annotation Data Table

### DIFF
--- a/app/src/components/CRUDTable.vue
+++ b/app/src/components/CRUDTable.vue
@@ -83,11 +83,6 @@
     })
   }
 
-  // Annotate a message [Not implemented]
-  function annotateMessage(item: Message) {
-
-  }
-
   // Search
   function updateSearch() {
     search.value = tempSearch.value
@@ -99,7 +94,6 @@
 </script>
 
 <template>
-  <h1>Hello!</h1>
   <v-data-table-server
     :items-length="numItems"
     :items="props.items"
@@ -193,6 +187,7 @@
     <template v-slot:item.actions="{ item }">
       <v-icon size="small" class="me-2" @click="editItem(item)" icon="mdi-pencil"></v-icon>
       <v-icon size="small" @click="deleteItem(item)" icon="mdi-delete"></v-icon>
+      <slot name="actions" :input="item"></slot>
     </template>
     <template v-slot:no-data>
       <v-btn color="primary" @click="loadItems"> Load Messages </v-btn>

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -24,6 +24,14 @@ const router = createRouter({
       // this generates a separate chunk (About.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
       component: () => import('../views/CodeView.vue')
+    },
+    {
+      path: '/messages/:messageID',
+      name: 'annotations',
+      // route level code-splitting
+      // this generates a separate chunk (About.[hash].js) for this route
+      // which is lazy-loaded when the route is visited.
+      component: () => import('../views/AnnotationView.vue'),
     }
   ]
 })

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -1,14 +1,31 @@
 interface Message {
   id: number,
-  content: string
+  content: string,
 }
 
 interface Code {
   id: number,
-  code: string
+  code: string,
 }
 
 interface Sorting {
   key: string,
-  order: string
+  order: string,
+}
+
+interface Annotation {
+  id: number,
+  start_idx: number,
+  end_idx: number,
+  code_id: number,
+  message_id: number,
+}
+
+interface AnnotationWithCode {
+  id: number,
+  start_idx: number,
+  end_idx: number,
+  code_id: number,
+  message_id: number,
+  code: string,
 }

--- a/app/src/views/AnnotationView.vue
+++ b/app/src/views/AnnotationView.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+  import { ref, type Ref } from 'vue'
+  import axios from 'axios'
+  import CRUDTable from '../components/CRUDTable.vue'
+  import { API_URL } from '@/main';
+  import { useRoute } from 'vue-router';
+
+  const route = useRoute()
+
+  const props = defineProps<{
+    messageContent: string,
+  }>()
+
+  const annotations: Ref<AnnotationWithCode[]> = ref([]);
+  const headers = ref([
+    { title: 'ID', key: 'id',  align: 'start', useInForm: false },
+    { title: 'Start Idx', key: 'start_idx', align: 'start', useInForm: true },
+    { title: 'End Idx', key: 'end_idx', align: 'start', useInForm: true },
+    { title: 'Code ID', key: 'code_id', align: 'start', useInForm: true },
+    { title: 'Code', key: 'code', sortable: true, align: 'start', useInForm: false },
+    { title: 'Actions', key: 'actions', useInForm: false }
+  ]);
+  const loading = ref(false);
+  const title = props.messageContent;
+  const sortBy = ref([{key: 'code', order: 'asc'}]);
+  const defaultAnnotation: AnnotationWithCode = {  // Default to restore the input annotation to
+    id: -1,
+    start_idx: -1,
+    end_idx: -1,
+    code_id: -1,
+    message_id: -1,
+    code: "",
+  }
+
+
+  // Database CRUD operations
+  function createAnnotation(annotation: AnnotationWithCode) : void {
+    const params = {
+      message_id: route.params.messageID,
+      code_id: annotation.code_id,
+      start_idx: annotation.start_idx,
+      end_idx: annotation.end_idx,
+    }
+    axios.post(API_URL + `annotations/${route.params.messageID}/create/`, params)
+      .then((response: { data: [Annotation, Code] }) => {
+        annotations.value.push({...response.data[1], ...response.data[0]});
+      })
+      .catch((error: any) => {
+        console.error(error);
+      })
+  }
+
+  async function getAnnotations() {
+    loading.value = true;
+    axios.get(API_URL + `annotations/${route.params.messageID}/`)
+      .then(
+        (response: {data: {result: [Annotation, Code]}[]}) => {
+          annotations.value = response.data.map((item) => {
+            return {...item.result[1], ...item.result[0]}})
+        },
+        () => {annotations.value = []}
+      )
+      .catch((error: any) => {
+        console.error(error);
+      })
+      .finally(() => {loading.value = false;})
+  };
+
+  async function updateAnnotation(annotation: AnnotationWithCode) {
+    const annotationIndex = annotations.value.findIndex(item => item.id === annotation.id);
+    annotations.value[annotationIndex] = annotation;
+    axios.post(API_URL + 'annotations/update/', { ...annotation })
+      .catch((error: any) => {
+        console.error(error);
+      })
+
+  }
+
+  async function deleteAnnotation(annotation: AnnotationWithCode) {
+    axios.post(API_URL + 'annotations/delete/', { id: annotation.id })
+      .then(() => {
+        annotations.value.splice(annotations.value.indexOf(annotation), 1);
+      })
+      .catch((error: any) => {
+        console.error(error);
+    })
+
+  }
+
+</script>
+
+
+<template>
+  <CRUDTable
+    @createItem="createAnnotation"
+    @fetchItems="getAnnotations"
+    @deleteItem="deleteAnnotation"
+    @editItem="updateAnnotation"
+    :items="annotations"
+    :title="title"
+    :headers="headers"
+    :loading="loading"
+    :defaultItem="defaultAnnotation"
+    :sortBy="sortBy"
+  >
+  </CRUDTable>
+</template>

--- a/app/src/views/MessageView.vue
+++ b/app/src/views/MessageView.vue
@@ -3,6 +3,7 @@
   import axios from 'axios'
   import CRUDTable from '../components/CRUDTable.vue'
   import { API_URL } from '@/main';
+  import router from '@/router';
 
   const messages: Ref<Message[]> = ref([]);
   const headers = ref([
@@ -68,11 +69,10 @@
       .catch((error: any) => {
         console.error(error);
       })
-
   }
 
-  function annotateDBMessage(message: Message) {
-
+  function annotateMessage(message: Message) {
+    router.push({ name: 'annotations', params: {messageID: message.id}})
   }
 </script>
 
@@ -90,5 +90,8 @@
     :defaultItem="defaultMessage"
     :sortBy="sortBy"
   >
+  <template #actions="actionProps : { input: Message }">
+    <v-icon size="small" @click="annotateMessage(actionProps.input)" icon="mdi-clipboard"></v-icon>
+  </template>
   </CRUDTable>
 </template>

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -164,6 +164,20 @@ def read_annotations(session: Session, message_id: int) -> List[sch.AnnotationRe
     ]
 
 
+def update_annotation(session: Session, annotation: sch.UpdateAnnotation) -> None:
+    statement = (
+        sa.update(Annotation)
+        .where(Annotation.id == annotation.id)
+        .values(
+            code_id=annotation.code_id,
+            start_idx=annotation.start_idx,
+            end_idx=annotation.end_idx,
+        )
+    )
+    session.execute(statement)
+    session.commit()
+
+
 def delete_annotation(session: Session, annotation: sch.DeleteAnnotation) -> None:
     statement = sa.delete(Annotation).where(Annotation.id == annotation.id)
     session.execute(statement)

--- a/backend/main.py
+++ b/backend/main.py
@@ -144,7 +144,7 @@ def count_codes(session: Session = session_dependency) -> int:
 # Annotations
 
 
-@app.get("/messages/{message_id}/")
+@app.get("/annotations/{message_id}/")
 def read_annotations(
     message_id: int,
     session: Session = session_dependency,
@@ -159,7 +159,7 @@ def read_annotations(
         raise HTTPException(status_code=404, detail="Message not found")
 
 
-@app.post("/messages/{message_id}/annotate/", response_model=Optional[sch.Annotation])
+@app.post("/annotations/{message_id}/create/", response_model=Optional[sch.Annotation])
 def create_annotation(
     annotation: sch.CreateAnnotation, session: Session = session_dependency
 ) -> models.Annotation:
@@ -168,6 +168,14 @@ def create_annotation(
         return crud.create_annotation(session=session, new_annotation=annotation)
     except MessageNotFoundError:
         raise HTTPException(status_code=404, detail="Message not found")
+
+
+@app.post("/annotations/update/")
+def update_annotation(
+    annotation: sch.UpdateAnnotation, session: Session = session_dependency
+) -> None:
+    """Update the content of a given annotation from the database."""
+    crud.update_annotation(session, annotation)
 
 
 @app.post("/annotations/delete/")


### PR DESCRIPTION
## What
A small PR implementing the 'annotate' action on the messages data table. This resolves #26.

## How
- Introduced a new page to the app 'messages/<message id>'.
- Re-used the CRUDTable to display and manipulate annotations.

## Where next?
This completes all of the requirements set out in the initial project brief. From here, bug fixes, documentation, testing and QoL improvements are coming.