### PR TITLE
[#38] Fix mypy CI failing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,5 @@ repos:
             - sqlalchemy>=2.0.21
             - alembic>=1.12.0
             - fastapi>=0.103.2
+            - pytest>=7.4.2
         args: [--config-file, setup.cfg]

--- a/tests/main.py
+++ b/tests/main.py
@@ -36,7 +36,7 @@ app.dependency_overrides[get_session] = override_get_session
 client = TestClient(app)
 
 
-@pytest.fixture()  # type: ignore
+@pytest.fixture()
 def test_db() -> Generator[None, None, None]:
     Base.metadata.create_all(bind=engine)
     yield


### PR DESCRIPTION
## What
A small PR fixing a mypy test that was failing due to an unused '#type: ignore'. This resolves #38.

## Why
A missing dependency in the mypy pre-commit hook lead me to add the #type: ignore, which was then unused by the CI workflow which sets up the entire pdm environment. Adding the dependency fixed the bug.